### PR TITLE
Fix: use manager command in the rock

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,7 +14,7 @@ platforms:
 services:
   training-operator:
     override: merge
-    command: "training-operator.v1"
+    command: "/manager"
     startup: enabled
     user: ubuntu
 
@@ -36,6 +36,18 @@ parts:
     source-tag: v1.8.0
     source-depth: 1
     source-subdir: cmd/training-operator.v1
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    override-build: |
+      # cd into $CRAFT_PART_SRC_WORK due to https://github.com/canonical/craft-parts/issues/427
+      cd $CRAFT_PART_SRC_WORK
+      go mod download
+      go build -a -o $CRAFT_PART_INSTALL/manager main.go
+    stage:
+      - manager
+    prime:
+      - manager
 
   non-root-user:
     plugin: nil

--- a/tests/test_rock.py
+++ b/tests/test_rock.py
@@ -44,7 +44,7 @@ def test_rock(rock_test_env):
             "exec",
             "ls",
             "-la",
-            "/bin/training-operator.v1",
+            "/manager",
         ],
         check=True,
     )


### PR DESCRIPTION
Closes: https://github.com/canonical/training-operator-rock/issues/3

The problem was that upstream code is relying that the `/manager` is present in the container. I had to rewrite the way we build the rock.

I have locally tested with the charm and integraiton tests are passing

To test rock:
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:training-operator_1.8.0_amd64.rock docker-daemon:misohu/training-operator:v1.8.0
docker run -ti misohu/training-operator:v1.8.0 -v
```

expected output:
```
2024-09-11T13:17:36.393Z [pebble] Started daemon.
2024-09-11T13:17:36.424Z [pebble] POST /v1/services 15.431847ms 202
2024-09-11T13:17:36.440Z [pebble] Service "training-operator" starting: /manager
2024-09-11T13:17:36.475Z [training-operator] 2024-09-11T13:17:36Z	ERROR	controller-runtime.client.config	unable to load in-cluster config	{"error": "unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"}
2024-09-11T13:17:36.475Z [training-operator] 2024-09-11T13:17:36Z	ERROR	controller-runtime.client.config	unable to get kubeconfig	{"error": "invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable", "errorCauses": [{"error": "no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}]}
2024-09-11T13:17:36.497Z [pebble] Change 1 task (Start service "training-operator") failed: cannot start service: exited quickly with code 1
2024-09-11T13:17:36.537Z [pebble] GET /v1/changes/1/wait 112.498142ms 200
2024-09-11T13:17:36.537Z [pebble] Started default services with change 1.
```