### PR TITLE
chore: upgrade training-operator 1.8.0 -> 1.9.0

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Source https://github.com/kubeflow/training-operator/blob/v1.8.0/build/images/training-operator/Dockerfile
+# Source https://github.com/kubeflow/training-operator/blob/v1.9.0/build/images/training-operator/Dockerfile
 name: training-operator
 summary: An image for Kubeflow Training Operator
 description: |
   Kubeflow Training Operator is a Kubernetes-native project for fine-tuning and scalable 
   distributed training of machine learning (ML) models created with various ML frameworks.
-version: "1.8.0"
+version: "1.9.0"
 license: Apache-2.0
 base: ubuntu@22.04
 
@@ -30,10 +30,10 @@ parts:
   training-operator:
     plugin: go
     build-snaps:
-      - go/1.22/stable
+      - go/1.23/stable
     source: https://github.com/kubeflow/training-operator
     source-type: git
-    source-tag: v1.8.0
+    source-tag: v1.9.0
     source-depth: 1
     source-subdir: cmd/training-operator.v1
     build-environment:


### PR DESCRIPTION
This commit bumps the version of golang and the image version to 1.9.0 to match upstream's Dockerfile.