### PR TITLE
chore(ci): update track branches in scan-images.yaml

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -10,7 +10,11 @@ jobs:
   scan-images:
     name: Scan published images and report vulnerabilities
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-published-images-scan-and-report.yaml@main
+    strategy:
+      matrix:
+        branch: [main, track/1.8]
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
       severity: "HIGH,CRITICAL"
+      branch: ${{ matrix.branch }}


### PR DESCRIPTION
Update track branches to the current supported ones. Note that main corresponds to the latest CKF version (1.10).

Ref canonical/bundle-kubeflow#1212