### PR TITLE
nit(ci): Polish job names for readability

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -6,7 +6,6 @@ on:
 jobs:
 
   on-pull-request:
-    name: Get rocks modified and build-scan-test them
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
     permissions:
       pull-requests: read

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -9,7 +9,6 @@ on:
 jobs:
 
   on-push:
-    name: Get rocks modified and build-scan-test-publish them
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
     permissions:
       pull-requests: read


### PR DESCRIPTION
nit(ci): Polish job names for readability

This is a complementary PR to canonical/charmed-kubeflow-workflows#113.
Polish job names to enhance readability in PR page:
  * Remove parent job name
  * Rename on pull request job to a shorter name

Close canonical/charmed-kubeflow-workflows#49

## CI
CI is expected to fail since there is no rock-ci-metadata.yaml file yet.