### PR TITLE
chore: upgrade `training-operator` to `v1.9.3`

### DIFF
--- a/training-operator/rockcraft.yaml
+++ b/training-operator/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Source https://github.com/kubeflow/training-operator/blob/v1.9.0/build/images/training-operator/Dockerfile
+# Source https://github.com/kubeflow/training-operator/blob/v1.9.3/build/images/training-operator/Dockerfile
 name: training-operator
 summary: An image for Kubeflow Training Operator
 description: |
   Kubeflow Training Operator is a Kubernetes-native project for fine-tuning and scalable 
   distributed training of machine learning (ML) models created with various ML frameworks.
-version: "1.9.0"
+version: "1.9.3"
 license: Apache-2.0
 base: ubuntu@22.04
 
@@ -33,7 +33,7 @@ parts:
       - go/1.23/stable
     source: https://github.com/kubeflow/training-operator
     source-type: git
-    source-tag: v1.9.0
+    source-tag: v1.9.3
     source-depth: 1
     source-subdir: cmd/training-operator.v1
     build-environment:


### PR DESCRIPTION
resolves https://github.com/canonical/training-operator-rock/issues/23

NOTE: the upstream Dockerfile for version `v1.9.3` is the same as the one for version `v1.9.0`.