### PR TITLE
feat: add Kubernetes JobSet rock

### DIFF
--- a/jobset/rock-ci-metadata.yaml
+++ b/jobset/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/jobset/rockcraft.yaml
+++ b/jobset/rockcraft.yaml
@@ -41,5 +41,5 @@ parts:
       - GOOS: linux
     override-build: |
       cd $CRAFT_PART_SRC
-      go mod download
-      go build -a -o $CRAFT_PART_INSTALL/manager
+      make build GO_BUILD_ENV='CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS}'
+      cp bin/manager $CRAFT_PART_INSTALL

--- a/jobset/rockcraft.yaml
+++ b/jobset/rockcraft.yaml
@@ -40,11 +40,6 @@ parts:
       - CGO_ENABLED: 0
       - GOOS: linux
     override-build: |
-      # cd into $CRAFT_PART_SRC_WORK due to https://github.com/canonical/craft-parts/issues/427
-      cd $CRAFT_PART_SRC_WORK
+      cd $CRAFT_PART_SRC
       go mod download
-      go build -a -o $CRAFT_PART_INSTALL/manager main.go
-    stage:
-      - manager
-    prime:
-      - manager
+      go build -a -o $CRAFT_PART_INSTALL/manager

--- a/jobset/rockcraft.yaml
+++ b/jobset/rockcraft.yaml
@@ -1,0 +1,50 @@
+# Source https://github.com/kubernetes-sigs/jobset/blob/v0.8.2/Dockerfile
+name: jobset
+summary: An image for Kubernetes JobSet
+description: |
+  JobSet is a Kubernetes-native API for managing a group of k8s Jobs as a unit.
+  It aims to offer a unified API for deploying HPC (e.g., MPI) and AI/ML training workloads (PyTorch, Jax, Tensorflow etc.) on Kubernetes.
+version: "0.8.2"
+license: Apache-2.0
+base: ubuntu@22.04
+
+platforms:
+  amd64:
+
+services:
+  jobset:
+    override: merge
+    command: "/manager"
+    startup: enabled
+
+run-user: _daemon_
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > \
+       ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  jobset:
+    plugin: go
+    build-snaps:
+      - go/1.23/stable
+    source: https://github.com/kubernetes-sigs/jobset
+    source-type: git
+    source-tag: v0.8.2
+    source-depth: 1
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    override-build: |
+      # cd into $CRAFT_PART_SRC_WORK due to https://github.com/canonical/craft-parts/issues/427
+      cd $CRAFT_PART_SRC_WORK
+      go mod download
+      go build -a -o $CRAFT_PART_INSTALL/manager main.go
+    stage:
+      - manager
+    prime:
+      - manager

--- a/jobset/tests/test_rock.py
+++ b/jobset/tests/test_rock.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+
+import random
+import string
+import subprocess
+
+import pytest
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/manager",
+        ],
+        check=True,
+    )

--- a/jobset/tox.ini
+++ b/jobset/tox.ini
@@ -1,0 +1,51 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."

--- a/jobset/tox.ini
+++ b/jobset/tox.ini
@@ -21,7 +21,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
     # export rock to docker


### PR DESCRIPTION
This PR adds the rock for Kubernetes [JobSet](https://github.com/kubernetes-sigs/jobset). This rock is required by Kubeflow Trainer V2 to manage a group of jobs as a single unit.

Merging this PR will close #22 