### PR TITLE
feat: add automated backport support (Training Operator V2)

### DIFF
--- a/.github/automatic_backport_tracks.yaml
+++ b/.github/automatic_backport_tracks.yaml
@@ -1,0 +1,3 @@
+automatic_backport_tracks:
+  -   track/2.0
+  -   track/2.1

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -4,6 +4,14 @@ on:
   pull_request:
 
 jobs:
+  populate-labels:
+    name: Populate labels
+    if: github.base_ref == 'main-v2' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/populate-labels.yaml@main
+    secrets: inherit
+    with:
+      track_file_path: ".github/automatic_backport_tracks.yaml"
+      label_prefix: "backport "
 
   on-pull-request:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main

--- a/.github/workflows/on_pull_request_closed.yaml
+++ b/.github/workflows/on_pull_request_closed.yaml
@@ -1,0 +1,23 @@
+name: On Pull Request Closed
+
+# When a pull request is pushed on the main branch, automatically
+# create backport PRs according to the labels on the pull request.
+# If there are conflicts, create a PR but leave it as draft.
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+    - main-v2
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+
+  backport:
+    name: Backport pull request
+    if: github.event.pull_request.merged
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/backport-pr.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Base issue: https://github.com/canonical/bundle-kubeflow/issues/1421

This PR enables automatic creation of backports based on labels. Labels are automatically assigned on each new PR merged on `main-v2` based on the value of the `.github/automatic_backport_tracks`.